### PR TITLE
Handle service account conditions when assigning roles

### DIFF
--- a/deploy_solution.sh
+++ b/deploy_solution.sh
@@ -41,6 +41,9 @@ if [ -n "$NEW_SERVICE_ACCOUNT" ]; then
 fi
 
 echo "Assigning required roles to the service account ${SERVICE_ACCOUNT}"
+# Iterate over the roles and check if the service account already has that role
+# assigned. If it has then skip adding that policy binding as using
+# --condition=None can overwrite any existing conditions in the binding.
 CURRENT_POLICY=$(gcloud projects get-iam-policy ${PROJECT_ID} --format=json)
 MEMBER="serviceAccount:${SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com"
 

--- a/deploy_solution.sh
+++ b/deploy_solution.sh
@@ -41,11 +41,19 @@ if [ -n "$NEW_SERVICE_ACCOUNT" ]; then
 fi
 
 echo "Assigning required roles to the service account ${SERVICE_ACCOUNT}"
+CURRENT_POLICY=$(gcloud projects get-iam-policy ${PROJECT_ID} --format=json)
+MEMBER="serviceAccount:${SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com"
+
 while IFS= read -r role || [[ -n "$role" ]]
 do \
-gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-  --member="serviceAccount:${SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com" \
-  --role="$role"
+if echo "$CURRENT_POLICY" | jq -e --arg role "$role" --arg member "$MEMBER" '.bindings[] | select(.role == $role) | .members[] | select(. == $member)' > /dev/null; then \
+    echo "IAM policy binding already exists for member ${MEMBER} and role ${role}"
+else \
+    gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member="$MEMBER" \
+    --role="$role" \
+    --condition=None
+fi
 done < "roles.txt"
 
 echo -n "To build the container images of the application, provide the image tag (e.g. 1.0.0): "

--- a/tutorial.md
+++ b/tutorial.md
@@ -101,11 +101,18 @@ You can also set it to any existing service account.
 ---
 **Assign the required roles to the service account**
 ```bash
+CURRENT_POLICY=$(gcloud projects get-iam-policy <var>PROJECT_ID</var> --format=json)
+MEMBER="serviceAccount:<var>SERVICE_ACCOUNT</var>@<var>PROJECT_ID</var>.iam.gserviceaccount.com"
 while IFS= read -r role || [[ -n "$role" ]]
 do \
-gcloud projects add-iam-policy-binding <var>PROJECT_ID</var> \
-  --member="serviceAccount:<var>SERVICE_ACCOUNT</var>@<var>PROJECT_ID</var>.iam.gserviceaccount.com" \
-  --role="$role"
+if echo "$CURRENT_POLICY" | jq -e --arg role "$role" --arg member "$MEMBER" '.bindings[] | select(.role == $role) | .members[] | select(. == $member)' > /dev/null; then \
+    echo "IAM policy binding already exists for member ${MEMBER} and role ${role}"
+else \
+    gcloud projects add-iam-policy-binding <var>PROJECT_ID</var> \
+    --member="$MEMBER" \
+    --role="$role" \
+    --condition=None
+fi
 done < "roles.txt"
 ```
 


### PR DESCRIPTION
Check if an IAM policy binding already exists (which might already have some IAM conditions), if it does then skip assigning the role. Else create an IAM policy binding with `--condition=None`.